### PR TITLE
feat(render): add alwaysRenderItemSelected option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ or
 | renderItem         | (item) => JSX.Element                                | No        | Takes an item from data and renders it into the list                |
 | onFocus            | () => void                                           | No        | Callback that is called when the dropdown is focused                |
 | onBlur             | () => void                                           | No        | Callback that is called when the dropdown is blurred                |
+| alwaysRenderSelectedItem | Boolean                                        | No        | Always show the list of selected items                              |
 
 
 #### SelectCountry extends Dropdown 

--- a/src/MultiSelect/index.tsx
+++ b/src/MultiSelect/index.tsx
@@ -55,7 +55,8 @@ const MultiSelectComponent = React.forwardRef((props: MultiSelectProps, currentR
     onFocus,
     onBlur,
     showsVerticalScrollIndicator = true,
-    dropdownPosition = 'auto'
+    dropdownPosition = 'auto',
+    alwaysRenderItemSelected = false
   } = props;
 
   const ref = useRef<View>(null);
@@ -390,7 +391,7 @@ const MultiSelectComponent = React.forwardRef((props: MultiSelectProps, currentR
         {_renderDropdown()}
         {_renderModal()}
       </View>
-      {!visible && _renderItemSelected()}
+      {(!visible || alwaysRenderItemSelected) && _renderItemSelected()}
     </>
   );
 });

--- a/src/MultiSelect/type.ts
+++ b/src/MultiSelect/type.ts
@@ -31,6 +31,7 @@ interface IProps {
   renderInputSearch?: (onSearch: (text:string) => void) => JSX.Element | null | undefined;
   onFocus?:() => void;
   onBlur?:() => void;
+  alwaysRenderItemSelected: boolean;
 };
 
 export type MultiSelectProps = IProps;


### PR DESCRIPTION
Hello, thanks for yout work.

The goal of this PR is to make the list of selected item always visible.
I have the case where the design requires that activecolor be close to the color of the none active items, render Selected item makes it more understandable for the user that he has selected correctly.

<img src="https://user-images.githubusercontent.com/58283299/147876174-e6630765-a613-4f0f-aa7e-1d9294a8bfa5.jpg" width="150">

 