### PR TITLE
Update deprecated Node v10 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   default:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:lts
     working_directory: ~/project
 
 commands:


### PR DESCRIPTION
This package is using an unmaintained Node.js image to run the CI. I think the best is update to the `lts` tag.

A better approach could be use a matrix build using Node.js v14, v16 and v18. To check if this package is compatible with the current LTS versions and also the current version (coming to LTS in October).