### PR TITLE
feat: Exposes style prop for text in dropdown component

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -51,6 +51,7 @@ const DropdownComponent = React.forwardRef<any, DropdownProps>(
       selectedTextStyle,
       inputSearchStyle,
       iconStyle,
+      textStyle,
       selectedTextProps,
       data,
       labelField,

--- a/src/components/Dropdown/model.ts
+++ b/src/components/Dropdown/model.ts
@@ -21,6 +21,7 @@ export type DropdownProps = {
   selectedTextProps?: TextProps;
   inputSearchStyle?: StyleProp<TextStyle>;
   iconStyle?: StyleProp<ImageStyle>;
+  textStyle?: StyleProp<TextStyle>;
   maxHeight?: number;
   fontFamily?: string;
   iconColor?: string;


### PR DESCRIPTION
Hello! I was using this component for my project and I realized that I couldn't change the font size and color of the text in the dropdown component. This change simply exposes that style prop. Thank you!