### PR TITLE
fixed from .measure to .measureInWindow

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -157,7 +157,7 @@ const DropdownComponent: <T>(
 
     const _measure = useCallback(() => {
       if (ref && ref?.current) {
-        ref.current.measure((_width, _height, px, py, fx, fy) => {
+        ref.current.measureInWindow((fx, fy, px, py) => {
           const isFull = orientation === 'LANDSCAPE' && !isTablet;
           const w = Math.floor(px);
           const top = isFull ? 20 : Math.floor(py) + Math.floor(fy) + 2;
@@ -603,9 +603,9 @@ const DropdownComponent: <T>(
                       !isTopPosition
                         ? { paddingTop: extendHeight }
                         : {
-                            justifyContent: 'flex-end',
-                            paddingBottom: extendHeight,
-                          },
+                          justifyContent: 'flex-end',
+                          paddingBottom: extendHeight,
+                        },
                     ])}
                   >
                     <View


### PR DESCRIPTION
### Changed the function .measure to .measureInWindow
.measure shows incorrect values in android when the status bar is translucent which results in creation of a gap between Flatlist and the dropdown itself. 

## Without StatusBar Translucent  .measure method
![Without StatusBar Translucent  measure ](https://user-images.githubusercontent.com/83276424/222903983-b337a401-f0f0-4e74-9ddb-013539f0192f.png)

## With StatusBar Translucent  .measure method
![With StatusBar Translucent  measure ](https://user-images.githubusercontent.com/83276424/222903979-0a47ed28-1360-4cb5-be82-510200d019cd.png)

## With StatusBar Translucent  .measureInWindow method
![With StatusBar Translucent  .measureInWindow method](https://user-images.githubusercontent.com/83276424/222904148-c9e7e5cf-e969-4095-88f2-5d97afe3fa14.png)

