### PR TITLE
feat: adds type safety to `valueField` & `labelField` props

### DIFF
--- a/src/components/Dropdown/model.ts
+++ b/src/components/Dropdown/model.ts
@@ -37,8 +37,8 @@ export interface DropdownProps<T> {
   data: T[];
   value?: T | string | null | undefined;
   placeholder?: string;
-  labelField: string;
-  valueField: string;
+  labelField: keyof T;
+  valueField: keyof T;
   searchField?: string;
   search?: boolean;
   searchPlaceholder?: string;


### PR DESCRIPTION
The user can type anything in `valueField` and `labelField` props since they aren`t type safety, causing errors when typing keys that doesn't exists. This PR will fix it.

This type safety also helps the user typing what he wants since the intellisense will be available for these props.

before:
![Captura de tela de 2023-03-06 00-31-59](https://user-images.githubusercontent.com/52337966/223014457-e577a730-f4a2-47e4-ac61-537a9de17a8b.png)

after:
![Captura de tela de 2023-03-06 00-39-29](https://user-images.githubusercontent.com/52337966/223014501-52e55633-be04-43c0-805a-8c4d1329379d.png)

