### PR TITLE
Updated exports to use types for TS@3.8.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import Dropdown from './components/Dropdown';
 import MultiSelect from './components/MultiSelect';
 import SelectCountry from './components/SelectCountry';
-import { IDropdownRef } from './components/Dropdown/model';
-import { IMultiSelectRef } from './components/MultiSelect/model';
+import type { IDropdownRef } from './components/Dropdown/model';
+import type { IMultiSelectRef } from './components/MultiSelect/model';
 
-export { Dropdown, MultiSelect, SelectCountry, IDropdownRef, IMultiSelectRef };
+export { Dropdown, MultiSelect, SelectCountry, type IDropdownRef, type IMultiSelectRef };


### PR DESCRIPTION
Updated index.tsx to comply with type import & exporting.

I am not familiar with TS and I could not get it to build / run as the yarn version used is much older than mine and I just was not bothered, but I believe this change should affect the required changes when compiled (stripping type exports).

Resolves https://github.com/hoaphantn7604/react-native-element-dropdown/issues/174

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html