### PR TITLE
Move container width to immediate parent of modal FlatList

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -610,9 +610,6 @@ const DropdownComponent: <T>(
                   <View
                     style={StyleSheet.flatten([
                       styles.flex1,
-                      {
-                        width,
-                      },
                       !isTopPosition
                         ? { paddingTop: extendHeight }
                         : {
@@ -624,6 +621,7 @@ const DropdownComponent: <T>(
                   >
                     <View
                       style={StyleSheet.flatten([
+                        { width },
                         styles.container,
                         isFull ? styleHorizontal : styleVertical,
                         containerStyle,


### PR DESCRIPTION
This fixes a bug on Android that causes the scrollable dropdown modal to ignore scroll gestures.  The current behavior creates a container that is limited width but places the FlatList outside of that container.