### PR TITLE
fix -  MultiSelect icons visible variable returns the correct value

### DIFF
--- a/src/components/MultiSelect/index.tsx
+++ b/src/components/MultiSelect/index.tsx
@@ -757,7 +757,7 @@ const MultiSelectComponent: <T>(
           onPress={showOrClose}
         >
           <View style={styles.dropdownInside}>
-            {renderLeftIcon?.()}
+            {renderLeftIcon?.(visible)}
             {value && value?.length > 0 ? (
               _renderItemSelected(true)
             ) : (
@@ -772,7 +772,7 @@ const MultiSelectComponent: <T>(
               </Text>
             )}
             {renderRightIcon ? (
-              renderRightIcon()
+              renderRightIcon(visible)
             ) : (
               <Image
                 source={ic_down}


### PR DESCRIPTION
Fix multiSelect always returns undefined in renderLeftIcon and renderRightIcon