### PR TITLE
Add input search placeholder text color

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ yarn add react-native-element-dropdown
 | search             | Boolean                                         | No        | Show or hide input search                                           |
 | searchQuery        | (keyword: string, labelValue: string) => Boolean| No        | Callback used to filter the list of items                           |
 | inputSearchStyle   | ViewStyle                                       | No        | Styling for input search                                            |
+| searchPlaceholderTextColor   | String                                | No        | Search placeholder color                                            |
 | searchPlaceholder  | String                                          | No        | The string that will be rendered before text input has been entered |
 | renderInputSearch  | (onSearch: (text:string) => void) => JSX.Element| No        | Customize TextInput search                                          |
 | disable            | Boolean                                         | No        | Specifies the disabled state of the Dropdown                        |
@@ -120,6 +121,7 @@ yarn add react-native-element-dropdown
 | search             | Boolean                                              | No        | Show or hide input search                                           |
 | searchQuery        | (keyword: string, labelValue: string) => Boolean     | No        | Callback used to filter the list of items                           |
 | inputSearchStyle   | ViewStyle                                            | No        | Styling for input search                                            |
+| searchPlaceholderTextColor   | String                                     | No        | Search placeholder color                                            |
 | searchPlaceholder  | String                                               | No        | The string that will be rendered before text input has been entered |
 | renderInputSearch  | (onSearch: (text:string) => void) => JSX.Element     | No        | Customize TextInput search                                          |
 | disable            | Boolean                                              | No        | Specifies the disabled state of the Dropdown                        |

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -62,6 +62,7 @@ const DropdownComponent: <T>(
       activeColor = '#F6F7F8',
       fontFamily,
       iconColor = 'gray',
+      searchPlaceholderTextColor = 'gray',
       searchPlaceholder,
       placeholder = 'Select item',
       search = false,
@@ -488,7 +489,7 @@ const DropdownComponent: <T>(
                 }
                 onSearch(e);
               }}
-              placeholderTextColor="gray"
+              placeholderTextColor={searchPlaceholderTextColor}
               iconStyle={[{ tintColor: iconColor }, iconStyle]}
             />
           );
@@ -499,6 +500,7 @@ const DropdownComponent: <T>(
       accessibilityLabel,
       font,
       iconColor,
+      searchPlaceholderTextColor,
       iconStyle,
       inputSearchStyle,
       onChangeText,

--- a/src/components/Dropdown/model.ts
+++ b/src/components/Dropdown/model.ts
@@ -33,6 +33,7 @@ export interface DropdownProps<T> {
   minHeight?: number;
   fontFamily?: string;
   iconColor?: string;
+  searchPlaceholderTextColor?: string;
   activeColor?: string;
   data: T[];
   value?: T | string | null | undefined;

--- a/src/components/MultiSelect/index.tsx
+++ b/src/components/MultiSelect/index.tsx
@@ -61,6 +61,7 @@ const MultiSelectComponent: <T>(
       fontFamily,
       placeholderStyle,
       iconColor = 'gray',
+      searchPlaceholderTextColor = 'gray',
       inputSearchStyle,
       searchPlaceholder,
       placeholder = 'Select item',
@@ -487,7 +488,7 @@ const MultiSelectComponent: <T>(
                 }
                 onSearch(e);
               }}
-              placeholderTextColor="gray"
+              placeholderTextColor={searchPlaceholderTextColor}
               iconStyle={[{ tintColor: iconColor }, iconStyle]}
             />
           );
@@ -498,6 +499,7 @@ const MultiSelectComponent: <T>(
       accessibilityLabel,
       font,
       iconColor,
+      searchPlaceholderTextColor,
       iconStyle,
       inputSearchStyle,
       onChangeText,

--- a/src/components/MultiSelect/model.ts
+++ b/src/components/MultiSelect/model.ts
@@ -33,6 +33,7 @@ export interface MultiSelectProps<T> {
   maxSelect?: number;
   fontFamily?: string;
   iconColor?: string;
+  searchPlaceholderTextColor?: string;
   activeColor?: string;
   data: T[];
   value?: string[] | null | undefined;


### PR DESCRIPTION
Hey @hoaphantn7604! 

This PR adds a new prop `searchPlaceholderTextColor` to both `Dropdown` and `MultiSelect`. I needed it in my project to be able to change search placeholder color and support light/dark modes.

Let me know if I missed something.

Thanks!
Mohamed