### PR TITLE
Remove padding from item containers

### DIFF
--- a/src/components/Dropdown/styles.ts
+++ b/src/components/Dropdown/styles.ts
@@ -39,7 +39,6 @@ export const styles = StyleSheet.create({
     writingDirection: I18nManager.isRTL ? 'rtl' : 'ltr',
   },
   item: {
-    padding: 17,
     flexDirection: I18nManager.isRTL ? 'row-reverse' : 'row',
     justifyContent: 'space-between',
     alignItems: 'center',


### PR DESCRIPTION
 This instead can be set in the style given to the `itemContainerStyle` (it doesn't seem to override for me)
It may also be worth checking to see other values in the hard coded styles that the module user can't change