### PR TITLE
Adding Option To Allow Pushing Selected Items To The Top of Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ yarn add react-native-element-dropdown
 | itemTestIDField    | String                                               | No        | Add this field to the input data. Ex: DATA = [{itemTestIDField: '', label: '', value:: ''}]|
 | accessibilityLabel | String          | No    | Set an accessibilityLabel on the view, so that people who use VoiceOver know what element they have selected |
 | itemAccessibilityLabelField | String                                      | No        | Add this field to the input data. Ex: DATA = [{itemAccessibilityLabelField: '', label: '', value:: ''}]|
-|-----------------------------|---------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------|
+|------|------|------|------|
 | selectedToTop      | Boolean                                              | No        | Put selected items on top of the list                                                                  |
-|-----------------------------|---------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------|
+|------|------|------|------|
 
 
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ yarn add react-native-element-dropdown
 | itemTestIDField    | String                                               | No        | Add this field to the input data. Ex: DATA = [{itemTestIDField: '', label: '', value:: ''}]|
 | accessibilityLabel | String          | No    | Set an accessibilityLabel on the view, so that people who use VoiceOver know what element they have selected |
 | itemAccessibilityLabelField | String                                      | No        | Add this field to the input data. Ex: DATA = [{itemAccessibilityLabelField: '', label: '', value:: ''}]|
+|-----------------------------|---------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------|
+| selectedToTop      | Boolean                                              | No        | Put selected items on top of the list                                                                  |
+|-----------------------------|---------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------|
 
 
 

--- a/src/components/MultiSelect/index.tsx
+++ b/src/components/MultiSelect/index.tsx
@@ -93,6 +93,7 @@ const MultiSelectComponent: <T>(
       itemAccessibilityLabelField,
       visibleSelectedItem = true,
       mode = 'default',
+      selectedToTop = false,
     } = props;
 
     const ref = useRef<View>(null);
@@ -519,7 +520,11 @@ const MultiSelectComponent: <T>(
               accessibilityLabel={accessibilityLabel + ' flatlist'}
               {...flatListProps}
               keyboardShouldPersistTaps="handled"
-              data={listData}
+              data={selectedToTop
+                  ? listData
+                      .filter((item) => checkSelected(item))
+                      .concat(listData.filter((item) => !checkSelected(item)))
+                  : listData}
               inverted={isTopPosition ? inverted : false}
               renderItem={_renderItem}
               keyExtractor={(_item, index) => index.toString()}

--- a/src/components/MultiSelect/index.tsx
+++ b/src/components/MultiSelect/index.tsx
@@ -520,11 +520,13 @@ const MultiSelectComponent: <T>(
               accessibilityLabel={accessibilityLabel + ' flatlist'}
               {...flatListProps}
               keyboardShouldPersistTaps="handled"
-              data={selectedToTop
+              data={
+                selectedToTop
                   ? listData
                       .filter((item) => checkSelected(item))
                       .concat(listData.filter((item) => !checkSelected(item)))
-                  : listData}
+                  : listData
+              }
               inverted={isTopPosition ? inverted : false}
               renderItem={_renderItem}
               keyExtractor={(_item, index) => index.toString()}

--- a/src/components/MultiSelect/model.ts
+++ b/src/components/MultiSelect/model.ts
@@ -35,6 +35,7 @@ export interface MultiSelectProps<T> {
   iconColor?: string;
   activeColor?: string;
   data: T[];
+  selectedToTop?: boolean;
   value?: string[] | null | undefined;
   placeholder?: string;
   labelField: keyof T;


### PR DESCRIPTION
While using the component with large list (5000+), it felt much easier if I can see the selected items first, epically if I am using  
`visibleSelectedItem={false}`, so I added an optional `selectedToTop` Boolean property that will trigger this behavior.

simply it will filter the `data` twice and using the `checkSelected()` method

![Media_240103_133343](https://github.com/hoaphantn7604/react-native-element-dropdown/assets/17522597/5538621c-17b9-43b9-9d87-4afcc12e7d34)

I tested the speed and it's just fine

I hope you like it and approve, I've started programming few months ago and this is my first contribution, I hope it's of some value.