### PR TITLE
Fix: scrollToIndex out of range: item length 0 but minimum is 1

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -253,7 +253,7 @@ const DropdownComponent: <T>(
             const index = _.findIndex(listData, (e: any) =>
               _.isEqual(defaultValue, _.get(e, valueField))
             );
-            if (index > -1 && index <= listData.length - 1) {
+            if (index > -1 && !_.isEmpty(listData.length) && index <= listData.length - 1) {
               refList?.current?.scrollToIndex({
                 index: index,
                 animated: false,


### PR DESCRIPTION
Error: 
scrollToIndex out of range: item length 0 but minimum is 1

How to reproduce?

1. Have data of enough length such that on search, the list should scroll
2. Select an item that is not rendered initially when the search is clicked, we have to persist this data for the next re-render
3. On next re-render, open search, and enter string which does not exist in list