### PR TITLE
fix: inputSearchStyle applied correctly 

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -481,7 +481,7 @@ const DropdownComponent: <T>(
               testID={testID + ' input'}
               accessibilityLabel={accessibilityLabel + ' input'}
               style={[styles.input, inputSearchStyle]}
-              inputStyle={[inputSearchStyle, font()]}
+              inputStyle={font()}
               value={searchText}
               autoCorrect={false}
               placeholder={searchPlaceholder}


### PR DESCRIPTION
inputSearchStyle is applied both to the search box and the placeholder text. if for example i want to add a border to the search box, it is applied both to it and the text inside of it. this fixes the issue by no longer applying the styling to the text 