### PR TITLE
Determine auto dropdown position by half of the screen height

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -568,7 +568,7 @@ const DropdownComponent: <T>(
             return bottom < keyboardHeight + height;
           }
 
-          return bottom < (search ? 150 : 100);
+          return bottom < (H * 0.5);
         };
 
         if (width && top && bottom) {
@@ -645,8 +645,8 @@ const DropdownComponent: <T>(
       }
       return null;
     }, [
+      H,
       visible,
-      search,
       position,
       keyboardHeight,
       maxHeight,

--- a/src/components/MultiSelect/index.tsx
+++ b/src/components/MultiSelect/index.tsx
@@ -559,7 +559,7 @@ const MultiSelectComponent: <T>(
             return bottom < keyboardHeight + height;
           }
 
-          return bottom < (search ? 150 : 100);
+          return bottom < (H * 0.5);
         };
 
         if (width && top && bottom) {
@@ -636,8 +636,8 @@ const MultiSelectComponent: <T>(
       }
       return null;
     }, [
+      H,
       visible,
-      search,
       position,
       keyboardHeight,
       maxHeight,


### PR DESCRIPTION
Issue:
The bottom space is small to show a reasonable size of dropdown when `dropdownPosition` is `auto` and it shows at `bottom` after calculation. Because of bottom space of value `100` and `150` (`search = true`) are determined as enough to show the dropdown in `bottom`.

Solution:
Determine bottom space by half of the device height