### PR TITLE
Add ability to set active item text style

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ yarn add react-native-element-dropdown
 | itemContainerStyle | TextStyle                                       | No        | Styling for item container in list                                  |
 | itemTextStyle      | TextStyle                                       | No        | Styling for text item in list                                       |
 | activeColor        | String                                          | No        | Background color for item selected in list container                |
+| activeItemTextStyle | TextStyle                                      | No        | Text style for item selected in list container                      |
 | search             | Boolean                                         | No        | Show or hide input search                                           |
 | searchQuery        | (keyword: string, labelValue: string) => Boolean| No        | Callback used to filter the list of items                           |
 | inputSearchStyle   | ViewStyle                                       | No        | Styling for input search                                            |
@@ -113,6 +114,7 @@ yarn add react-native-element-dropdown
 | iconStyle          | ImageStyle                                           | No        | Styling for icon                                                    |
 | iconColor          | String                                               | No        | Color of icons                                                      |
 | activeColor        | String                                               | No        | Background color for item selected in list container                |
+| activeItemTextStyle | TextStyle                                           | No        | Text style for item selected in list container                      |
 | itemContainerStyle | TextStyle                                            | No        | Styling for item container in list                                  |
 | itemTextStyle      | TextStyle                                            | No        | Styling for text item in list                                       |
 | selectedStyle      | ViewStyle                                            | No        | Styling for selected view                                           |

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -61,6 +61,7 @@ const DropdownComponent: <T>(
       searchField,
       value,
       activeColor = '#F6F7F8',
+      activeItemTextStyle,
       fontFamily,
       iconColor = 'gray',
       searchPlaceholder,
@@ -486,6 +487,7 @@ const DropdownComponent: <T>(
                     style={StyleSheet.flatten([
                       styles.textItem,
                       itemTextStyle,
+                      selected && activeItemTextStyle,
                       font(),
                     ])}
                   >
@@ -500,6 +502,7 @@ const DropdownComponent: <T>(
       [
         accessibilityLabel,
         activeColor,
+        activeItemTextStyle,
         currentValue,
         font,
         itemAccessibilityLabelField,

--- a/src/components/Dropdown/model.ts
+++ b/src/components/Dropdown/model.ts
@@ -34,6 +34,7 @@ export interface DropdownProps<T> {
   fontFamily?: string;
   iconColor?: string;
   activeColor?: string;
+  activeItemTextStyle?: StyleProp<TextStyle>;
   data: T[];
   value?: T | string | null | undefined;
   placeholder?: string;

--- a/src/components/MultiSelect/index.tsx
+++ b/src/components/MultiSelect/index.tsx
@@ -57,6 +57,7 @@ const MultiSelectComponent: <T>(
       itemTextStyle,
       iconStyle,
       activeColor = '#F6F7F8',
+      activeItemTextStyle,
       containerStyle,
       fontFamily,
       placeholderStyle,
@@ -479,6 +480,7 @@ const MultiSelectComponent: <T>(
                     style={StyleSheet.flatten([
                       styles.textItem,
                       itemTextStyle,
+                      selected && activeItemTextStyle,
                       font(),
                     ])}
                   >
@@ -493,6 +495,7 @@ const MultiSelectComponent: <T>(
       [
         accessibilityLabel,
         activeColor,
+        activeItemTextStyle,
         checkSelected,
         font,
         itemAccessibilityLabelField,

--- a/src/components/MultiSelect/model.ts
+++ b/src/components/MultiSelect/model.ts
@@ -34,6 +34,7 @@ export interface MultiSelectProps<T> {
   fontFamily?: string;
   iconColor?: string;
   activeColor?: string;
+  activeItemTextStyle?: StyleProp<TextStyle>;
   data: T[];
   value?: string[] | null | undefined;
   placeholder?: string;


### PR DESCRIPTION
Implement the ability to allow for users to specift a `TextStyle` for the active (_selected_) item(s) in the dropdown list.
<img src="https://github.com/hoaphantn7604/react-native-element-dropdown/assets/79180508/2bedf4c6-0517-4318-8163-c2eed372f060" alt="drawing" width="400"/>