### PR TITLE
Fixing sizing and position issues with Math.floor for dropdown

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -206,11 +206,11 @@ const DropdownComponent: <T>(
 
           setPosition({
             isFull,
-            width: Math.floor(width),
+            width: width,
             top: Math.floor(top + statusBarHeight),
             bottom: Math.floor(bottom - statusBarHeight),
-            left: Math.floor(left),
-            height: Math.floor(height),
+            left: left,
+            height: height,
           });
         });
       }


### PR DESCRIPTION
When testing this library, I found that removing the Math.floor would get the correct size of the parent component, whereas with it would end up short in many cases both for width and left specifically