### PR TITLE
FIx useEffect infinite loop

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -148,10 +148,12 @@ const DropdownComponent: <T>(
     );
 
     useEffect(() => {
-      const filterData = excludeData(data);
-      setListData([...filterData]);
-      if (searchText) {
-        onSearch(searchText);
+      if (data && data.length > 0) {
+        const filterData = excludeData(data);
+        setListData([...filterData]);
+        if (searchText) {
+          onSearch(searchText);
+        }
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data, searchText]);


### PR DESCRIPTION
For some reason, when you put an empty array for the data
it starts an infinite rendering loop. I made a quick fix to stop the rendering
when the data is an empty array. 