### PR TITLE
Fixing left icon to use field instead of being hardcoded to 'image'

### DIFF
--- a/src/components/SelectCountry/index.tsx
+++ b/src/components/SelectCountry/index.tsx
@@ -20,6 +20,7 @@ const SelectCountryComponent: <T>(
       valueField,
       labelField,
       imageField,
+      iconField,
       selectedTextStyle,
       imageStyle,
     } = props;
@@ -59,10 +60,10 @@ const SelectCountryComponent: <T>(
         {...props}
         renderItem={_renderItem}
         renderLeftIcon={() => {
-          if (selectItem?.image) {
+          if (selectItem && selectItem[iconField]) {
             return (
               <Image
-                source={selectItem.image}
+                source={selectItem[iconField]}
                 style={[styles.image, imageStyle]}
               />
             );


### PR DESCRIPTION
Using 'iconField' for left icon in Select Country

Initially changed this to also use 'imageValue', as that seems to be the most obvious case but why not allow for more freedom.